### PR TITLE
Pr1

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,7 +37,7 @@ Using the prototyping work as a guide implement the final scene graph library wi
     * Support for Text rendering
 * Development of test suite of programs and data
 * Support for RTX Mesh shaders and ray tracing
-* Support for integration with OpenGL/OSG applications via [EXT\_external\_object](https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_external_objects.txt)
+* Support for integration with OpenGL/OSG applications via [EXT\_external\_object](https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_external_objects.txt) & [VK\_KHR\_external\_memory](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VK_KHR_external_memory.html#versions-1.1-promotions)
 * Port to iOS
 
 ### 4. Release Phase,  Fall 2019 onwards

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,6 +37,7 @@ Using the prototyping work as a guide implement the final scene graph library wi
     * Support for Text rendering
 * Development of test suite of programs and data
 * Support for RTX Mesh shaders and ray tracing
+* Support for integration with OpenGL/OSG applications via [EXT\_external\_object](https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_external_objects.txt)
 * Port to iOS
 
 ### 4. Release Phase,  Fall 2019 onwards

--- a/include/vsg/core/Array.h
+++ b/include/vsg/core/Array.h
@@ -58,6 +58,18 @@ namespace vsg
             _size(numElements),
             _data(new value_type[numElements]) {}
 
+        template<typename... Args>
+        static ref_ptr<Array> create(Args... args)
+        {
+            return ref_ptr<Array>(new Array(args...));
+        }
+
+        static ref_ptr<Array> create(std::initializer_list<value_type> l)
+        {
+            return ref_ptr<Array>(new Array(l));
+        }
+
+
         std::size_t sizeofObject() const noexcept override { return sizeof(Array); }
 
         // implementation provided by Visitor.h

--- a/include/vsg/core/Array2D.h
+++ b/include/vsg/core/Array2D.h
@@ -55,6 +55,12 @@ namespace vsg
             _height(height),
             _data(new value_type[width * height]) {}
 
+        template<typename... Args>
+        static ref_ptr<Array2D> create(Args... args)
+        {
+            return ref_ptr<Array2D>(new Array2D(args...));
+        }
+
         std::size_t sizeofObject() const noexcept override { return sizeof(Array2D); }
 
         // implementation provided by Visitor.h

--- a/include/vsg/core/Array3D.h
+++ b/include/vsg/core/Array3D.h
@@ -59,6 +59,12 @@ namespace vsg
             _depth(depth),
             _data(new value_type[width * height * depth]) {}
 
+        template<typename... Args>
+        static ref_ptr<Array3D> create(Args... args)
+        {
+            return ref_ptr<Array3D>(new Array3D(args...));
+        }
+
         std::size_t sizeofObject() const noexcept override { return sizeof(Array3D); }
 
         // implementation provided by Visitor.h

--- a/include/vsg/core/Value.h
+++ b/include/vsg/core/Value.h
@@ -47,6 +47,12 @@ namespace vsg
         explicit Value(Args... args) :
             _value(args...) {}
 
+        template<typename... Args>
+        static ref_ptr<Value> create(Args... args)
+        {
+            return ref_ptr<Value>(new Value(args...));
+        }
+
         std::size_t sizeofObject() const noexcept override { return sizeof(Value); }
 
         // implementation provided by Visitor.h

--- a/include/vsg/core/Value.h
+++ b/include/vsg/core/Value.h
@@ -43,6 +43,10 @@ namespace vsg
         explicit Value(const value_type& in_value) :
             _value(in_value) {}
 
+        template<typename... Args>
+        explicit Value(Args... args) :
+            _value(args...) {}
+
         std::size_t sizeofObject() const noexcept override { return sizeof(Value); }
 
         // implementation provided by Visitor.h

--- a/include/vsg/viewer/Camera.h
+++ b/include/vsg/viewer/Camera.h
@@ -138,7 +138,7 @@ namespace vsg
         dvec3 up;
     };
 
-    class Camera : public Inherit<Object, Object>
+    class Camera : public Inherit<Object, Camera>
     {
     public:
         Camera();

--- a/include/vsg/vk/DeviceMemory.h
+++ b/include/vsg/vk/DeviceMemory.h
@@ -98,6 +98,12 @@ namespace vsg
             T::assign(args..., static_cast<value_type*>(pData));
         }
 
+        template<typename... Args>
+        static ref_ptr<MappedData> create(Args... args)
+        {
+            return ref_ptr<MappedData>(new MappedData(args...));
+        }
+
         virtual ~MappedData()
         {
             T::dataRelease(); // make sure that the Array doesn't delete this memory

--- a/src/vsg/vk/ComputePipeline.cpp
+++ b/src/vsg/vk/ComputePipeline.cpp
@@ -98,7 +98,7 @@ ComputePipeline::Implementation::Result ComputePipeline::Implementation::create(
         stageInfo.pSpecializationInfo = &specializationInfo;
 
         // assign the values from the ShaderStage into the specializationInfo
-        specializationInfo.mapEntryCount = shaderStage->getSpecializationMapEntries().size();
+        specializationInfo.mapEntryCount = static_cast<uint32_t>(shaderStage->getSpecializationMapEntries().size());
         specializationInfo.pMapEntries = shaderStage->getSpecializationMapEntries().data();
         specializationInfo.dataSize = shaderStage->getSpecializationData()->dataSize();
         specializationInfo.pData = shaderStage->getSpecializationData()->dataPointer();

--- a/src/vsg/vk/GraphicsPipeline.cpp
+++ b/src/vsg/vk/GraphicsPipeline.cpp
@@ -142,14 +142,14 @@ GraphicsPipeline::Implementation::Result GraphicsPipeline::Implementation::creat
             shaderStageCreateInfo[i].pSpecializationInfo = &specializationInfo;
 
             // assign the values from the ShaderStage into the specializationInfo
-            specializationInfo.mapEntryCount = shaderStage->getSpecializationMapEntries().size();
+            specializationInfo.mapEntryCount = static_cast<uint32_t>(shaderStage->getSpecializationMapEntries().size());
             specializationInfo.pMapEntries = shaderStage->getSpecializationMapEntries().data();
             specializationInfo.dataSize = shaderStage->getSpecializationData()->dataSize();
             specializationInfo.pData = shaderStage->getSpecializationData()->dataPointer();
         }
     }
 
-    pipelineInfo.stageCount = shaderStageCreateInfo.size();
+    pipelineInfo.stageCount = static_cast<uint32_t>(shaderStageCreateInfo.size());
     pipelineInfo.pStages = shaderStageCreateInfo.data();
 
     for (auto pipelineState : pipelineStates)


### PR DESCRIPTION
## Description
fix compile warning in visual studio community 2019 16.1.4
warning C4267:  '=': conversion from 'size_t' to 'uint32_t', possible loss of data

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Not tested (binary unchanged)

## Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
